### PR TITLE
Add support for aarch64 in graalvm-ce builds

### DIFF
--- a/src/github-com-graalvm.js
+++ b/src/github-com-graalvm.js
@@ -27,10 +27,11 @@ const fetch = require('node-fetch')
         }
         const os = (
           url.includes('linux-amd64') ? 'linux' :
-            url.includes('darwin-amd64') || url.includes('macos-amd64') ? 'darwin' :
-              url.includes('windows-amd64') ? 'windows' : null
+            url.includes('linux-aarch64') ? 'linux' :
+              url.includes('darwin-amd64') || url.includes('macos-amd64') ? 'darwin' :
+                url.includes('windows-amd64') ? 'windows' : null
         )
-        const arch = 'amd64'
+        const arch = url.includes('linux-aarch64') ? 'aarch64' : 'amd64'
         const version = m[1].replace(/^(\d+[.]\d+[.]\d+)[.]\d+$/, '$1')
         const javaVersionMatch = url.match(/-java(\d+)-/)
         const ns = javaVersionMatch != null ? `graalvm-ce-java${javaVersionMatch[1]}` : 'graalvm-ce-java8'


### PR DESCRIPTION
This should add `aarch64` as the architecture for linux for graalvm ce builds.
This should solve https://github.com/shyiko/jabba/issues/716