### PR TITLE
Fix 4-part versions and other errors

### DIFF
--- a/src/github-com-graalvm.js
+++ b/src/github-com-graalvm.js
@@ -21,7 +21,7 @@ const fetch = require('node-fetch')
       }
       for (const asset of release.assets || []) {
         const url = asset.browser_download_url
-        if (url.endsWith('.jar')) {
+        if (url.endsWith('.jar') || url.endsWith('.sha256')) {
           console.error(`skip(ext): ${url}`)
           continue
         }


### PR DESCRIPTION
This PR fixes a number of errors that prevents the daily TravisCI build from completing correctly.

-  GraalVM was returning a `.jar.sha256` hash file with `v0.js` didn't understand. I added code to skip files with that extension to `github-com-graalvm.js`
- I made `v0.js` a little more robust in general by having it log an error and skipping something if it can't parse it for one reason or another, rather than failing entirely. It seems a little brittle to have the script fail entirely any time a version format changes or a new major version comes out. Now the script will continue to work and output the versions it understands.
- I added some extra error handling when versions couldn't be parsed so the script wouldn't fail with a NPE if the `String.match()` returned `null`
- The new `graalvm-ce-java16` namespace was unknown and caused `v0.js` to exit with an error. I added that to the namespaces map
- Several versions are now coming back with a four-part version string, e.g. `10.0.1.1`, which were not handled correctly in `v0.js`. I changed the patch version capture groups from `(?:.(\d+))?` to `(?:.(\d+(?:\.\d+)*))?` in a few places to handle version strings in this format without changing the matched capture groups. E.g. `10.0.1` is parsed to `['10', '0', '1']` (same as before) but `10.0.1.1` (previously unsupported) is now parsed to  `['10', '0', '1.1']`. 

Here's a diff of what the output looks like after the error handling changes (so I could get it running) and with the additional regex changes on top of that. I went thru it a few times to make sure I didn't break anything or accidentally change the format of any version strings

https://gist.github.com/camsaul/5e45ce637b568d39181e733c949ccb1b